### PR TITLE
FIX setting default values found in model

### DIFF
--- a/orm_mongodb.py
+++ b/orm_mongodb.py
@@ -532,6 +532,6 @@ class orm_mongodb(orm.orm_template):
         # get the default values defined in the object
         for f in fields_list:
             if f in self._defaults:
-                value[f] = self._defaults[f](self, cr, uid, context)
+                value[f] = self._defaults[f]
 
         return value


### PR DESCRIPTION
En indicar un valor per defecte a un model mongo i iniciar el openerp donava aquest error:

INFO:openerp.orm:setting default value for ['prova'] of collection giscedata_sips_ps
Traceback (most recent call last):
  File "./server/bin/openerp-server.py", line 107, in <module>
    pooler.get_db_and_pool(db, update_module=tools.config['init'] or tools.config['update'])
  File "/home/arua/erp/server/bin/pooler.py", line 42, in get_db_and_pool
    addons.load_modules(db, force_demo, status, update_module)
  File "/home/arua/erp/server/bin/addons/**init**.py", line 761, in load_modules
    r = load_module_graph(cr, graph, status, report=report)
  File "/home/arua/erp/server/bin/addons/**init**.py", line 605, in load_module_graph
    init_module_objects(cr, package.name, modules)
  File "/home/arua/erp/server/bin/addons/**init**.py", line 374, in init_module_objects
    result = obj._auto_init(cr, {'module': module_name})
  File "/home/arua/erp/server/bin/addons/mongodb_backend/orm_mongodb.py", line 94, in _auto_init
    def_values = self.default_get(cr, 1, def_fields)
  File "/home/arua/erp/server/bin/addons/mongodb_backend/orm_mongodb.py", line 535, in
default_get
    value[f] = self._defaults[f](self, cr, uid, context)
TypeError: 'str' object is not callable
