### PR TITLE
Use default port if not configured

### DIFF
--- a/mongodb2.py
+++ b/mongodb2.py
@@ -135,11 +135,11 @@ class MDBConn(object):
                                   tools.config['mongodb_port'],
                                   tools.config['mongodb_name'],
                                   tools.config['mongodb_auth'])
-            elif tools.config['mongodb_host'] and tools.config['mongodb_port']:
+            elif tools.config['mongodb_host']:
                 # No auth
                 uri_tmpl = 'mongodb://%s:%s/'
                 uri = uri_tmpl % (tools.config['mongodb_host'],
-                                  int(tools.config['mongodb_port']))
+                                  int(tools.config.get('mongodb_port', 27017)))
         return uri
 
     def mongo_connect(self):


### PR DESCRIPTION
If only mongodb_host is configured then use that host and default (27017) port if is not configured.
