### PR TITLE
Fix mongo order parser

### DIFF
--- a/orm_mongodb.py
+++ b/orm_mongodb.py
@@ -389,34 +389,42 @@ class orm_mongodb(orm.orm_template):
         return vals['id']
 
     def _compute_order(self, cr, user, order=None, context=None):
-        #Parse the order of the object to addapt it to MongoDB
+        # Parse the order of the object to addapt it to MongoDB
 
         if not order:
             order = self._order
 
         mongo_order = order.split(',')
-        #If we only have one order field
-        #it can contain asc or desc
-        #Otherwise is not allowed
+        # If we only have one order field
+        # it can contain asc or desc
+        # Otherwise is not allowed
         if len(mongo_order) == 1:
             reg_expr = '^(([a-z0-9_]+|"[a-z0-9_]+")( *desc)+( *, *|))+$'
             order_desc = re.compile(reg_expr, re.I)
             if order_desc.match(mongo_order[0].strip()):
                 return [(mongo_order[0].partition(' ')[0].strip(),
-                        pymongo.DESCENDING)]
+                         pymongo.DESCENDING)]
             else:
                 return [(mongo_order[0].partition(' ')[0].strip(),
-                        pymongo.ASCENDING)]
+                         pymongo.ASCENDING)]
         else:
             res = []
-            reg_expr = '^(([a-z0-9_]+|"[a-z0-9_]+")( *desc| *asc)+( *, *|))+$'
-            regex_order_mongo = re.compile(reg_expr, re.I)
+            reg_expr_desc = '^(([a-z0-9_]+|"[a-z0-9_]+")( *desc)+( *, *|))+$'
+            reg_expr_asc = '^(([a-z0-9_]+|"[a-z0-9_]+")( *asc)+( *, *|))+$'
+
+            regex_order_mongo_desc = re.compile(reg_expr_desc, re.I)
+            regex_order_mongo_asc = re.compile(reg_expr_asc, re.I)
             for field in mongo_order:
-                if regex_order_mongo.match(field.strip()):
-                    raise except_orm(_('Error'),
-                        _('Bad order declaration for model %s') % (self._name))
+                if regex_order_mongo_desc.match(field.strip()):
+                    res.append((field.strip().partition(' ')[0],
+                                pymongo.DESCENDING))
+                elif regex_order_mongo_asc.match(field.strip()):
+                    res.append((field.strip().partition(' ')[0],
+                                pymongo.ASCENDING))
                 else:
-                    res.append((field.strip(), pymongo.ASCENDING))
+                    raise except_orm(_('Error'),
+                                     _('Bad order declaration for model %s') % (
+                                         self._name))
         return res
 
     def search(self, cr, user, args, offset=0, limit=0, order=None,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,9 +2,11 @@ import unittest
 
 from mongodb_backend import testing
 from expects import *
+from destral.transaction import Transaction
 
 import doctest
 from mongodb_backend import mongodb2
+from mongodb_backend import orm_mongodb
 
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(mongodb2))
@@ -41,3 +43,27 @@ class MongoDBBackendTest(testing.MongoDBTestCase):
         expect(self.openerp.config.options).to(have_keys(
             mongodb_name=self.database
         ))
+
+    def test_compute_order_parsing(self):
+        class order_test(orm_mongodb.orm_mongodb):
+            _name = 'order.test'
+
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+
+            testing_class = order_test(cursor)
+
+            res = testing_class._compute_order(cursor, uid, 'test desc')
+            self.assertEqual(res, [('test', -1)])
+
+            res = testing_class._compute_order(cursor, uid, 'test asc')
+            self.assertEqual(res, [('test', 1)])
+
+            res = testing_class._compute_order(cursor, uid, 'test desc, '
+                                                            'test2 desc')
+            self.assertEqual(res, [('test', -1), ('test2', -1)])
+
+            res = testing_class._compute_order(cursor, uid, 'test asc, '
+                                                            'test2 desc')
+            self.assertEqual(res, [('test', 1), ('test2', -1)])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,9 +8,36 @@ import doctest
 from mongodb_backend import mongodb2
 from mongodb_backend import orm_mongodb
 
+
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(mongodb2))
     return tests
+
+
+def test_compute_order_parsing(self):
+    class order_test(orm_mongodb.orm_mongodb):
+        _name = 'order.test'
+
+    with Transaction().start(self.database) as txn:
+        cursor = txn.cursor
+        uid = txn.user
+
+        testing_class = order_test(cursor)
+
+        res = testing_class._compute_order(cursor, uid, 'test desc')
+        self.assertEqual(res, [('test', -1)])
+
+        res = testing_class._compute_order(cursor, uid, 'test asc')
+        self.assertEqual(res, [('test', 1)])
+
+        res = testing_class._compute_order(cursor, uid, 'test desc, '
+                                                        'test2 desc')
+        self.assertEqual(res, [('test', -1), ('test2', -1)])
+
+        res = testing_class._compute_order(cursor, uid, 'test asc, '
+                                                        'test2 desc')
+        self.assertEqual(res, [('test', 1), ('test2', -1)])
+
 
 class MongoDBBackendTest(testing.MongoDBTestCase):
 
@@ -43,27 +70,3 @@ class MongoDBBackendTest(testing.MongoDBTestCase):
         expect(self.openerp.config.options).to(have_keys(
             mongodb_name=self.database
         ))
-
-    def test_compute_order_parsing(self):
-        class order_test(orm_mongodb.orm_mongodb):
-            _name = 'order.test'
-
-        with Transaction().start(self.database) as txn:
-            cursor = txn.cursor
-            uid = txn.user
-
-            testing_class = order_test(cursor)
-
-            res = testing_class._compute_order(cursor, uid, 'test desc')
-            self.assertEqual(res, [('test', -1)])
-
-            res = testing_class._compute_order(cursor, uid, 'test asc')
-            self.assertEqual(res, [('test', 1)])
-
-            res = testing_class._compute_order(cursor, uid, 'test desc, '
-                                                            'test2 desc')
-            self.assertEqual(res, [('test', -1), ('test2', -1)])
-
-            res = testing_class._compute_order(cursor, uid, 'test asc, '
-                                                            'test2 desc')
-            self.assertEqual(res, [('test', 1), ('test2', -1)])


### PR DESCRIPTION
This PR aims to solve a problem detected in the parser of order parameters.
When mongo received more than one parameter to order by, it didn't work properly and ended up raising an exception.

References: https://github.com/gisce/erp/pull/4310
