### PR TITLE
Add orm_mongodb.exists method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .pydevproject
 .settings
 *.pyc
+.idea

--- a/i18n/ca_ES.po
+++ b/i18n/ca_ES.po
@@ -1,0 +1,45 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 
+# Translators:
+# Jaume  Florez Valenzuela <jflorez@gisce.net>, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: GISCE-ERP\n"
+"Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
+"POT-Creation-Date: 2017-10-24 11:27\n"
+"PO-Revision-Date: 2017-10-24 09:36+0000\n"
+"Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
+"Language-Team: Catalan (Spain) <erp@dev.gisce.net>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ca_ES\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: mongodb_backend
+#: model:ir.module.module,shortdesc:mongodb_backend.module_meta_information
+msgid "MongoDB Backend"
+msgstr "MongoDB Backend"
+
+#. module: mongodb_backend
+#: model:ir.module.module,description:mongodb_backend.module_meta_information
+msgid ""
+"\n"
+"NoSQL MongoDB backend for OpenERP. It allows to create objects and store\n"
+"all the data in a NoSQL way. You can interact with this data the same way\n"
+"as it was stored in PostgreSQL from the client.\n"
+"    "
+msgstr "\nNoSQL MongoDB backend per OpenERP. Permet la creació i emmagatzematge d'objectes mitjançant NoSQL. Es pot interactuar amb les dades de la mateixa manera que amb PostgreSQL desde el client.\n        "
+
+#. module: mongodb_backend
+#: code:addons/mongodb_backend/orm_mongodb.py:437
+#, python-format
+msgid "Error"
+msgstr "Error"
+
+#. module: mongodb_backend
+#: code:addons/mongodb_backend/orm_mongodb.py:438
+#, python-format
+msgid "Bad order declaration for model %s"
+msgstr "Declaració incorrecta del ordre per al model %s"

--- a/i18n/es_ES.po
+++ b/i18n/es_ES.po
@@ -1,0 +1,45 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 
+# Translators:
+# Jaume  Florez Valenzuela <jflorez@gisce.net>, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: GISCE-ERP\n"
+"Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
+"POT-Creation-Date: 2017-10-24 11:27\n"
+"PO-Revision-Date: 2017-10-24 09:34+0000\n"
+"Last-Translator: Jaume  Florez Valenzuela <jflorez@gisce.net>\n"
+"Language-Team: Spanish (Spain) <erp@dev.gisce.net>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_ES\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: mongodb_backend
+#: model:ir.module.module,shortdesc:mongodb_backend.module_meta_information
+msgid "MongoDB Backend"
+msgstr "MongoDB Backend"
+
+#. module: mongodb_backend
+#: model:ir.module.module,description:mongodb_backend.module_meta_information
+msgid ""
+"\n"
+"NoSQL MongoDB backend for OpenERP. It allows to create objects and store\n"
+"all the data in a NoSQL way. You can interact with this data the same way\n"
+"as it was stored in PostgreSQL from the client.\n"
+"    "
+msgstr "\nNoSQL MongoDB backend para OpenERP. Permite la creación y almacenaje de datos con NoSQL. Puede interactuar con los datos de la misma forma que con PostgreSQL desde el cliente.\n        "
+
+#. module: mongodb_backend
+#: code:addons/mongodb_backend/orm_mongodb.py:437
+#, python-format
+msgid "Error"
+msgstr "Error"
+
+#. module: mongodb_backend
+#: code:addons/mongodb_backend/orm_mongodb.py:438
+#, python-format
+msgid "Bad order declaration for model %s"
+msgstr "Mala declaración del orden para el modelo %s"

--- a/i18n/mongodb_backend.pot
+++ b/i18n/mongodb_backend.pot
@@ -1,0 +1,43 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* mongodb_backend
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 5.0.14\n"
+"Report-Msgid-Bugs-To: support@openerp.com\n"
+"POT-Creation-Date: 2017-10-24 11:27\n"
+"PO-Revision-Date: 2017-10-24 11:27\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: mongodb_backend
+#: model:ir.module.module,shortdesc:mongodb_backend.module_meta_information
+msgid "MongoDB Backend"
+msgstr ""
+
+#. module: mongodb_backend
+#: model:ir.module.module,description:mongodb_backend.module_meta_information
+msgid "\n"
+"NoSQL MongoDB backend for OpenERP. It allows to create objects and store\n"
+"all the data in a NoSQL way. You can interact with this data the same way\n"
+"as it was stored in PostgreSQL from the client.\n"
+"    "
+msgstr ""
+
+#. module: mongodb_backend
+#: code:addons/mongodb_backend/orm_mongodb.py:437
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: mongodb_backend
+#: code:addons/mongodb_backend/orm_mongodb.py:438
+#, python-format
+msgid "Bad order declaration for model %s"
+msgstr ""
+

--- a/orm_mongodb.py
+++ b/orm_mongodb.py
@@ -222,6 +222,18 @@ class orm_mongodb(orm.orm_template):
                 ss = self._columns[key]._symbol_set
                 vals[key] = ss[1](value)
 
+    def exists(self, cr, uid, ids, context=None):
+        collection = mdbpool.get_collection(self._table)
+
+        if not context:
+            context = {}
+        if not ids:
+            return False
+
+        mongo_cr = collection.find({'id': ids}, ['id'])
+        res = [x for x in mongo_cr]
+        return True if res else False
+
     def read(self, cr, user, ids, fields=None, context=None,
              load='_classic_read'):
 


### PR DESCRIPTION
Implements the _exists_ method from _orm.orm_template_ on _orm_mongodb.orm_mongodb_.

This method wasn't implemented in MongoDB ORM and returned "Method not Implemented" as defined in _orm.orm_template_. 