### PR TITLE
Corregir: añadir import de traducción.

### DIFF
--- a/orm_mongodb.py
+++ b/orm_mongodb.py
@@ -29,11 +29,13 @@ import gridfs
 from bson.objectid import ObjectId
 from datetime import datetime
 from numbers import Number
+from tools.translate import _
 
 #mongodb stuff
 try:
     from mongodb2 import mdbpool
 except ImportError:
+    import sys
     sys.stderr.write("ERROR: Import mongodb module\n")
 
 


### PR DESCRIPTION
Añadir el _import_ de traducción para evitar la excepción de variable global no definida. 

- [x] Añadir `from tools.translate import _`