### PR TITLE
deprecated_unique deprecated and set to default

### DIFF
--- a/orm_mongodb.py
+++ b/orm_mongodb.py
@@ -68,7 +68,6 @@ class orm_mongodb(orm.orm_template):
         collection = db[self._table]
         #Create index for the id field
         collection.ensure_index([('id', pymongo.ASCENDING)],
-                                deprecated_unique=None,
                                 ttl=300,
                                 unique=True)
 


### PR DESCRIPTION
`deprecated_unique` parameter is not available on later versions of mongo. Moreover, it was set to `None` which is already the default value en earlier versions. So not setting the parameter at all should do no harm.