### PR TITLE
FIX = operator AS $eq

### DIFF
--- a/mongodb2.py
+++ b/mongodb2.py
@@ -36,7 +36,7 @@ logger = netsvc.Logger()
 class MDBConn(object):
 
     OPERATOR_MAPPING = {
-        '=': lambda l1, l3: {l1: l3},
+        '=': lambda l1, l3: {l1: {'$eq': l3}},
         '!=': lambda l1, l3: {l1: {'$ne': l3}},
         '<=': lambda l1, l3: {l1: {'$lte': l3}},
         '>=': lambda l1, l3: {l1: {'$gte': l3}},
@@ -61,7 +61,7 @@ class MDBConn(object):
 
         >>> mdbconn = MDBConn()
         >>> mdbconn.translate_domain([('name', '=', 'ol')])
-        {'name': 'ol'}
+        {'name': {'$eq': 'ol'}}
         >>> mdbconn.translate_domain([('name', '!=', 'ol')])
         {'name': {'$ne': 'ol'}}
 


### PR DESCRIPTION
Changes equal operator (`=`) translation to the `$eq` operator. It allows mix equal and other operator in the same search:

This fails without this change
```python
model_obj.search(cursor, uid, [('a','=',3),('a','in', [3,4,5])]) 
```

```
Fault: <Fault 'int' object has no attribute 'update': 'Traceback (most recent call last):\n  File "/home/erp/src/erp/server/bin/netsvc.py", line 361, in dispatch\n    result = LocalService(service_name)(method, *params)\n  File "/home/erp/src/erp/server/bin/netsvc.py", line 100, in __call__\n    res = getattr(self, method)(*params)\n  File "/home/erp/src/erp/server/bin/service/web_services.py", line 584, in execute\n    res = service.execute(db, uid, object, method, *args)\n  File "/home/erp/src/erp/server/bin/osv/osv.py", line 61, in wrapper\n    return f(self, dbname, *args, **kwargs)\n  File "/home/erp/src/erp/server/bin/osv/osv.py", line 132, in execute\n    res = pool.execute_cr(cr, uid, obj, method, *args, **kw)\n  File "/home/erp/src/erp/server/bin/osv/osv.py", line 123, in execute_cr\n    return getattr(object, method)(cr, uid, *args, **kw)\n  File "/home/erp/src/erp/server/bin/addons/mongodb_backend/orm_mongodb.py", line 462, in search\n    new_args = mdbpool.translate_domain(tmp_args)\n  File "/home/erp/src/erp/server/bin/addons/mongodb_backend/mongodb2.py", line 106, in translate_domain\n    new_domain[field].update(clause[field])\nAttributeError: \'int\' object has no attribute \'update\'\n'>
```