### PR TITLE
Support python version 3.10

### DIFF
--- a/mongodb2.py
+++ b/mongodb2.py
@@ -21,7 +21,7 @@
 ##############################################################################
 
 import tools
-from pymongo import MongoClient, MongoReplicaSetClient
+from pymongo import MongoClient
 from pymongo.errors import AutoReconnect
 from pymongo.read_preferences import ReadPreference
 import re
@@ -158,7 +158,6 @@ class MDBConn(object):
             if tools.config['mongodb_replicaset']:
                 kwargs.update({'replicaSet': tools.config['mongodb_replicaset'],
                                'read_preference': ReadPreference.SECONDARY_PREFERRED})
-                mongo_client = MongoReplicaSetClient
 
             connection = mongo_client(self.uri, **kwargs)
         except Exception as e:
@@ -207,6 +206,7 @@ class MDBConn(object):
         try:
             db = self.connection[tools.config['mongodb_name']]
         except AutoReconnect:
+
             max_tries = 5
             count = 0
             while count < max_tries:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pymongo==2.9
+pymongo==2.9;python_version<="2.7.18"
+pymongo>=3.12;python_version>"2.7.18"
 six


### PR DESCRIPTION
MongoReplicaSetClient not required in python 2.7.18 and not supported in python 3.10
First pymongo version with python 3.10 support is pymongo==3.12 version.