### PR TITLE
Fix when register does not contains 'id' on search

### DIFF
--- a/orm_mongodb.py
+++ b/orm_mongodb.py
@@ -502,7 +502,7 @@ class orm_mongodb(orm.orm_template):
                     modifiers={"$snapshot": False},
                     sort=self._compute_order(cr, user, order))
 
-        res = [x['id'] for x in mongo_cr]
+        res = [x['id'] for x in mongo_cr if x.get('id')]
 
         return res
 

--- a/orm_mongodb.py
+++ b/orm_mongodb.py
@@ -502,7 +502,7 @@ class orm_mongodb(orm.orm_template):
                     modifiers={"$snapshot": False},
                     sort=self._compute_order(cr, user, order))
 
-        res = [x['id'] for x in mongo_cr if x.get('id')]
+        res = [x['id'] for x in mongo_cr if 'id' in x]
 
         return res
 


### PR DESCRIPTION
In some cases there is registers without 'id' key. CRM `[226458]`