### PR TITLE
use isolation repeatable read on export data 2

### DIFF
--- a/orm_mongodb.py
+++ b/orm_mongodb.py
@@ -30,7 +30,7 @@ from bson.objectid import ObjectId
 from datetime import datetime
 from numbers import Number
 from tools.translate import _
-from tools import readonly
+from tools.sql_utils import isolation
 import six
 import tools
 
@@ -252,7 +252,7 @@ class orm_mongodb(orm.orm_template):
         res = [x for x in mongo_cr]
         return True if res else False
 
-    @readonly()
+    @isolation(readonly=True, isolation_level='repeatable_read')
     def export_data2(self, cursor, uid, domain, limit, fields_to_export, format,
                      context=None):
         def get_human_name(path):


### PR DESCRIPTION
Avoids:

-[ RECORD 1 ]----+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
pid              | 1314364
backend_start    | 2024-07-31 14:53:11.893007+02
query_start      | 2024-08-01 12:51:20.70527+02
age              | 1 day 00:42:57.045863
usename          | erp
application_name | 524265-ERP-ERPWCLI-account.invoice-export_data2
state            | idle in transaction
query            | select res_id,value from ir_translation where lang='en_US' and type='model' and name='payment.type,name' and res_id in (1, 2) -- 524265-ERP-ERPWCLI-account.invoice-export_data2
