### PR TITLE
test: isolate MongoDB default config test

### DIFF
--- a/.github/workflows/ferretDB.yml
+++ b/.github/workflows/ferretDB.yml
@@ -100,6 +100,7 @@ jobs:
           pip install -r src/erp/requirements-dev.txt
           pip install -r src/erp/server/bin/addons/base/requirements.txt
           pip install -r src/oorq/requirements.txt
+          pip install pytz
           pip install pymongo==3.13.0
           pip install destral
 

--- a/.github/workflows/mongo3.yml
+++ b/.github/workflows/mongo3.yml
@@ -84,6 +84,7 @@ jobs:
           pip install -r src/erp/requirements-dev.txt
           pip install -r src/erp/server/bin/addons/base/requirements.txt
           pip install -r src/oorq/requirements.txt
+          pip install pytz
           pip install pymongo==3.13.0
           pip install destral
 

--- a/.github/workflows/mongo5.yml
+++ b/.github/workflows/mongo5.yml
@@ -84,6 +84,7 @@ jobs:
           pip install -r src/erp/requirements-dev.txt
           pip install -r src/erp/server/bin/addons/base/requirements.txt
           pip install -r src/oorq/requirements.txt
+          pip install pytz
           pip install pymongo==3.13.0
           pip install destral
 

--- a/.github/workflows/mongo8.yml
+++ b/.github/workflows/mongo8.yml
@@ -84,6 +84,7 @@ jobs:
           pip install -r src/erp/requirements-dev.txt
           pip install -r src/erp/server/bin/addons/base/requirements.txt
           pip install -r src/oorq/requirements.txt
+          pip install pytz
           pip install pymongo==3.13.0
           pip install destral
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -178,6 +178,33 @@ class MongoDBBackendTest(testing.MongoDBTestCase):
 
     def test_default_mongodb_name(self):
         from mongodb_backend.mongodb2 import mdbpool
+        # Module installation or previous tests can populate MongoDB defaults in
+        # the process-global OpenERP config. Own this test's precondition, but
+        # restore the process-global config after tearDown has dropped the test
+        # database.
+        managed_options = ('db_readonly',)
+
+        def is_mongodb_option(key):
+            return key.startswith('mongodb_') or key in managed_options
+
+        original_options = dict(
+            (key, self.openerp.config.options[key])
+            for key in self.openerp.config.options
+            if is_mongodb_option(key)
+        )
+
+        def restore_mongodb_options():
+            for key in list(self.openerp.config.options):
+                if is_mongodb_option(key):
+                    self.openerp.config.options.pop(key)
+            self.openerp.config.options.update(original_options)
+
+        self.addCleanup(restore_mongodb_options)
+        for key in list(self.openerp.config.options):
+            if is_mongodb_option(key):
+                self.openerp.config.options.pop(key)
+        mdbpool._connection = None
+
         expect(self.openerp.config.options).to_not(have_keys(
             'mongodb_name',
             'mongodb_port',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -180,37 +180,33 @@ class MongoDBBackendTest(testing.MongoDBTestCase):
         from mongodb_backend.mongodb2 import mdbpool
         # Module installation or previous tests can populate MongoDB defaults in
         # the process-global OpenERP config. Own this test's precondition, but
-        # restore the process-global config after tearDown has dropped the test
-        # database.
-        managed_options = ('db_readonly',)
-
-        def is_mongodb_option(key):
-            return key.startswith('mongodb_') or key in managed_options
-
+        # avoid clearing auth-related options: FerretDB runs need those
+        # credentials later in MongoDBTestCase.tearDown().
+        default_options = (
+            'mongodb_name',
+            'mongodb_port',
+            'mongodb_host',
+        )
         original_options = dict(
             (key, self.openerp.config.options[key])
             for key in self.openerp.config.options
-            if is_mongodb_option(key)
+            if key in default_options
         )
 
         def restore_mongodb_options():
-            for key in list(self.openerp.config.options):
-                if is_mongodb_option(key):
-                    self.openerp.config.options.pop(key)
+            for key in default_options:
+                self.openerp.config.options.pop(key, None)
             self.openerp.config.options.update(original_options)
 
         self.addCleanup(restore_mongodb_options)
-        for key in list(self.openerp.config.options):
-            if is_mongodb_option(key):
-                self.openerp.config.options.pop(key)
+        for key in default_options:
+            self.openerp.config.options.pop(key, None)
         mdbpool._connection = None
 
         expect(self.openerp.config.options).to_not(have_keys(
             'mongodb_name',
             'mongodb_port',
-            'mongodb_host',
-            'mongodb_user',
-            'mongodb_pass'
+            'mongodb_host'
         ))
         # After accessing to getting object variables are defined
         db = mdbpool.get_db()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -179,34 +179,24 @@ class MongoDBBackendTest(testing.MongoDBTestCase):
     def test_default_mongodb_name(self):
         from mongodb_backend.mongodb2 import mdbpool
         # Module installation or previous tests can populate MongoDB defaults in
-        # the process-global OpenERP config. Own this test's precondition, but
-        # avoid clearing auth-related options: FerretDB runs need those
-        # credentials later in MongoDBTestCase.tearDown().
-        default_options = (
-            'mongodb_name',
-            'mongodb_port',
-            'mongodb_host',
-        )
-        original_options = dict(
-            (key, self.openerp.config.options[key])
-            for key in self.openerp.config.options
-            if key in default_options
-        )
+        # the process-global OpenERP config. Own only this test's precondition:
+        # the Mongo database name must be absent so MDBConn falls back to the
+        # current OpenERP database. Keep connection and auth options intact
+        # because FerretDB requires them in MongoDBTestCase.tearDown().
+        original_mongodb_name = self.openerp.config.options.get('mongodb_name')
+        had_mongodb_name = 'mongodb_name' in self.openerp.config.options
 
-        def restore_mongodb_options():
-            for key in default_options:
-                self.openerp.config.options.pop(key, None)
-            self.openerp.config.options.update(original_options)
+        def restore_mongodb_name():
+            self.openerp.config.options.pop('mongodb_name', None)
+            if had_mongodb_name:
+                self.openerp.config.options['mongodb_name'] = original_mongodb_name
 
-        self.addCleanup(restore_mongodb_options)
-        for key in default_options:
-            self.openerp.config.options.pop(key, None)
+        self.addCleanup(restore_mongodb_name)
+        self.openerp.config.options.pop('mongodb_name', None)
         mdbpool._connection = None
 
         expect(self.openerp.config.options).to_not(have_keys(
-            'mongodb_name',
-            'mongodb_port',
-            'mongodb_host'
+            'mongodb_name'
         ))
         # After accessing to getting object variables are defined
         db = mdbpool.get_db()


### PR DESCRIPTION
## Objetivo

Refs TASK-88506.

Aislar el test `test_default_mongodb_name` para que sea compatible con la validación Python 2/3 sin depender del estado global de configuración que pueda haber dejado la instalación del módulo u otros tests.

## Cambios

- El test guarda y limpia únicamente `mongodb_name`, que es la precondición real que necesita validar.
- Mantiene intactas las opciones de conexión/autenticación (`mongodb_host`, `mongodb_port`, `mongodb_user`, `mongodb_pass`, `mongodb_auth`, etc.) para no romper FerretDB ni el `tearDown()` de `MongoDBTestCase`.
- Restaura el estado original de `mongodb_name` al terminar el test, evitando contaminación entre casos.
- Los workflows de CI instalan explícitamente `pytz`, requerido por `oorq` al arrancar Destral en Python 3.

## Validación

Ejecutado desde el worktree ERP enlazando este módulo en `server/bin/addons/mongodb_backend` antes del ajuste de CI:

- Python 2.7.18: `destral -m mongodb_backend` → 29 tests OK, 2 skipped.
- Python 3.11.15: `destral -m mongodb_backend` → 29 tests OK, 2 skipped.

Validación local posterior:

- `python3 -m py_compile tests/__init__.py` OK.
- `python -m py_compile tests/__init__.py` con Python 2.7 OK.
- Parse YAML de workflows `mongo3`, `mongo5`, `mongo8` y `ferretDB` OK.
- `git diff --check` OK.

## Notas

El fallo inicial venía de aislamiento de tests/configuración global, no de sintaxis Python 3 directa, pero bloqueaba la validación Py3 del módulo.

Tras dispararse CI en GitHub se detectaron dos problemas adicionales de entorno/test:

- Los jobs Python 3 fallaban antes de generar JUnit por `ModuleNotFoundError: No module named 'pytz'` al importar `oorq`.
- FerretDB fallaba si el test eliminaba opciones de conexión/autenticación necesarias para conectar y para ejecutar `drop_database` en `tearDown()`.

Ambos quedan cubiertos en commits posteriores.
